### PR TITLE
Improved geometric functions

### DIFF
--- a/pyLOM/vmmath/__init__.py
+++ b/pyLOM/vmmath/__init__.py
@@ -19,7 +19,7 @@ from .svd            import qr, svd, tsqr, randomized_qr, init_qr_streaming, upd
 # FFT routines
 from .fft            import hammwin, fft
 # Geometry and mesh routines
-from .geometric      import cellCenters, normals, euclidean_d, edge_normals, edge_to_cells, neighbors_dict, fix_normals_coherence
+from .geometric      import cellCenters, normals, euclidean_d, wall_normals, edge_to_cells, cell_adjacency, fix_normals_coherence
 # Regression routines
 from .regression     import least_squares, ridge_regresion
 # Data processing module


### PR DESCRIPTION
Some modifications and improvements have been made in geometric.py after testing the GNN:

    - edge_normals was renamed to wall_normals and now returns also the dual edges of the graph.

    - neighbors_dict was renamed to cell_adjacency.

    - edge_to_cells now assigns the adjacent cells of an edge not only to the edge itself but also to its reciprocal edge.

The changes in this PR have been tested to work as expected by the implementation of the GNN.