### PR TITLE
Fix `matmulp`

### DIFF
--- a/Examples/example_matmulp.py
+++ b/Examples/example_matmulp.py
@@ -18,7 +18,7 @@ B = np.array([
     [8, 6, 1, 7]], order = 'C', dtype = np.double)
 
 Ai = pyLOM.utils.mpi_scatter(A, root = 0, do_split = True)
-Ai = np.transpose(Ai)
+Ai = np.transpose(Ai).copy() # This is needed, otherwise only order=F is modified
 Bi = pyLOM.utils.mpi_scatter(B, root = 0, do_split = True)
 
 # NumPy matmul


### PR DESCRIPTION
In fact it was just a `.copy()` missing due to the way numpy handles the transpose.

Closes #236